### PR TITLE
Update spimclass.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
       license='MIT',
       download_url='https://github.com/Tom-P7/spimcube/archive/v_1.0.tar.gz',
       
-      install_requires=['matplotlib>=3.1', 'colorcet', 'numpy'],
+      install_requires=['matplotlib>=3.1', 'colorcet', 'numpy', 'despike'],
       
       author="Tom-P7",
       description="This package enables the exploration of datacube of spectra within a rich GUI interface.",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,9 @@ setup(
       version='1.0',
       packages=['spimcube'],
       license='MIT',
-      download_url='https://github.com/Tom-P7/spimcube/archive/v_1.0.tar.gz',
+      
+      #download_url='https://github.com/Tom-P7/spimcube/archive/v_1.0.tar.gz',
+      # --> Not needed anymore
       
       install_requires=['matplotlib>=3.1', 'colorcet', 'numpy', 'despike'],
       

--- a/spimcube/spimclass.py
+++ b/spimcube/spimclass.py
@@ -6,7 +6,7 @@ import re
 import colorcet as cc
 import copy
 import statistics as stat
-
+import despike
 import spimcube.functions as fct
 
 

--- a/spimcube/spimclass.py
+++ b/spimcube/spimclass.py
@@ -42,7 +42,7 @@ class Spim:
     -------
 
     """
-    def __init__(self, path, filename, scan_direction='hl'):
+    def __init__(self, path, filename, scan_direction='hl', clean_spike=False):
 
         """
         Parameters
@@ -52,11 +52,15 @@ class Spim:
                          Example: 'hl' means scanning by successive horizontal lines from left to right.
                                   'vt' means scanning by successive vertical lines from top to bottom.
                          Default is 'hl'.
+        clean_spike : bool (default : False)
+                      If True, the method ``intensity_map`` returns an image after cleaning the spikes with
+                      ``despike.clean``.
                          
         """
         self.path = path
         self.filename = filename
         self.scan_direction = scan_direction
+        self.clean_spike = clean_spike
         
         # Data attributes
         self.matrix = None
@@ -202,7 +206,7 @@ class Spim:
             self.xpmin, self.xpmax = [0, 0], [len(self.x_range)-1, self.x_range[-1]]
             self.ypmin, self.ypmax = [0, 0], [len(self.y_range)-1, self.y_range[-1]]
         
-    def intensity_map(self, center=None, width=None):
+    def intensity_map(self, center=None, width=None, clean_spike=self.clean_spike):
         """Builds the intensity image data in the desired spectral range.
         
         Generate a 2D array contening intensity of the PL integrated over the chosen range in wavelength.
@@ -223,6 +227,9 @@ class Spim:
                         self.int_lambda_min[0]:self.int_lambda_max[0]+1],
             axis=2,
         )
+        if clean_spike:
+            # Clean the image from the spikes.
+            image_data = despike.clean(image_data)
         return image_data / np.max(image_data)
 
 
@@ -257,7 +264,7 @@ class SpimInterface:
     -------
     
     """
-    def __init__(self, spim, lambda_init=None):
+    def __init__(self, spim, lambda_init=None, fig_fc='dimgrey', spec_fc='whitesmoke'):
         """
         Parameters
         ----------
@@ -287,8 +294,8 @@ class SpimInterface:
         vsp1, vsp2 = 0.03, 0.015
         
         # Figure and main axes - attributes
-        self.fig = plt.figure(figsize=(14, 6.54), facecolor='dimgrey')
-        self.ax_spectrum  = self.fig.add_axes([l1, b0, w0, h0], facecolor='whitesmoke')
+        self.fig = plt.figure(figsize=(14, 6.54), facecolor=fig_fc)
+        self.ax_spectrum  = self.fig.add_axes([l1, b0, w0, h0], facecolor=spec_fc)
         for spine in self.ax_spectrum.spines.values():
             spine.set_lw(1.7)
             spine.set_color('k')#'dimgrey'


### PR DESCRIPTION
Pierre:

Pour l'interpolation 'spline16' il te suffit d'accéder à l'attribut par la méthode classique:
>> si = sc.SpimInterface(spim)
>> si.image.set_interpolation('spline16') # or 'gaussian' or others
Donc pas besoin de coder ça en dur
Si tu veux connaitre toutes les méthodes et attributs de l'object 'SpimInterface' tu peux taper:
>> dir(si)

En revanche,

Pour le cleaning de l'intensity image que tu veux faire, j'ai ajouté l'attribut 'clean_spike' qu'on peut entrer en paramètre du constructeur de Spim. Il utilise la fonction 'despike.clean', mais l'implémentation actuelle ne permet pas de changer les paramètres de cette fonction. A voir plus tard, si c'est nécessaire on pourrait passer un dictionnaire à 'clean_spike' contenant la fonction à utiliser et ses paramètres.

Concernant l'esthétique, j'ai ajouté 2 paramètres à SpimInterface 'fig_fc' et 'spec_fc' pour choisir la couleur de fond de la figure et du spectre.